### PR TITLE
More cleanup

### DIFF
--- a/src/areahandler.hpp
+++ b/src/areahandler.hpp
@@ -26,12 +26,12 @@ class AreaHandler: public osmium::handler::Handler {
     }
 
     void error_message(const osmium::Area &area) {
-        cerr << "AreaHandler: Error at ";
+        std::cerr << "AreaHandler: Error at ";
         if (area.from_way())
-            cerr << "way: ";
+            std::cerr << "way: ";
         else
-            cerr << "relation: ";
-        cerr << area.orig_id() << endl;
+            std::cerr << "relation: ";
+        std::cerr << area.orig_id() << '\n';
     }
 
     void insert_in_polygon_tree(const osmium::Area &area) {
@@ -42,7 +42,7 @@ class AreaHandler: public osmium::handler::Handler {
                                             .release();
         } catch (...) {
             error_message(area);
-            cerr << "While init polygon_tree." << endl;
+            std::cerr << "While init polygon_tree.\n";
             return;
         }
 
@@ -52,7 +52,7 @@ class AreaHandler: public osmium::handler::Handler {
                 prepared_polygon = new prepared_polygon_type(geos_polygon);
             } catch (...) {
                 error_message(area);
-                cerr << "While init polygon_tree." << endl;
+                std::cerr << "While init polygon_tree.\n";
                 continue;
             }
             const geos::geom::Envelope *envelope;
@@ -94,7 +94,7 @@ public:
             error_message(area);
         } catch (...) {
             error_message(area);
-            cerr << "Unexpected error" << endl;
+            std::cerr << "Unexpected error\n";
         }
     }
 };

--- a/src/datastorage.hpp
+++ b/src/datastorage.hpp
@@ -208,15 +208,6 @@ private:
         node_map[last_node].push_back(last_idx);
     }
 
-    void destroy_polygons() {
-        for (auto polygon : prepared_polygon_set) {
-            delete polygon;
-        }
-        for (auto multipolygon : multipolygon_set) {
-            delete multipolygon;
-        }
-    }
-
 public:
     /***
      * node_map: Contains all first_nodes and last_nodes of found waterways with
@@ -230,8 +221,8 @@ public:
      */
     google::sparse_hash_map<osmium::object_id_type, std::vector<std::size_t>> node_map;
     google::sparse_hash_map<osmium::object_id_type, ErrorSum*> error_map;
-    google::sparse_hash_set<geos::geom::prep::PreparedPolygon*> prepared_polygon_set;
-    google::sparse_hash_set<geos::geom::MultiPolygon*> multipolygon_set;
+    std::vector<std::unique_ptr<geos::geom::prep::PreparedPolygon>> prepared_polygon_set;
+    std::vector<std::unique_ptr<geos::geom::MultiPolygon>> multipolygon_set;
     geos::index::strtree::STRtree polygon_tree;
 
     explicit DataStorage(std::string outfile) :
@@ -241,12 +232,6 @@ public:
         init_db();
         node_map.set_deleted_key(-1);
         error_map.set_deleted_key(-1);
-        prepared_polygon_set.set_deleted_key(nullptr);
-        multipolygon_set.set_deleted_key(nullptr);
-    }
-
-    ~DataStorage() {
-        destroy_polygons();
     }
 
     WaterWay& get_waterway(const size_t offset) {

--- a/src/datastorage.hpp
+++ b/src/datastorage.hpp
@@ -12,6 +12,7 @@
 
 #include <memory>
 #include <vector>
+#include <google/sparse_hash_map>
 
 #include <gdalcpp.hpp>
 

--- a/src/datastorage.hpp
+++ b/src/datastorage.hpp
@@ -27,11 +27,6 @@ typedef osmium::handler::NodeLocationsForWays<index_pos_type,
                                               index_neg_type>
         location_handler_type;
 
-//struct OGRGeometryDeleter {
-//  void operator()(OGRGeometry* geom) const {
-//    OGRGeometryFactory::destroyGeometry(geom);
-//  }
-//};
 
 class DataStorage {
     std::string output_filename;
@@ -76,8 +71,6 @@ class DataStorage {
             }
         }
     };
-
-    std::vector<WaterWay*> waterways;
 
     void init_db() {
         CPLSetConfigOption("OGR_SQLITE_PRAGMA", "journal_mode=OFF,TEMP_STORE=MEMORY,temp_store=memory,LOCKING_MODE=EXCLUSIVE");
@@ -207,7 +200,6 @@ class DataStorage {
                       osmium::object_id_type last_node,
                       const std::string name, const std::string& type) {
         WaterWay *wway = new WaterWay(first_node, last_node, std::move(name), type);
-        waterways.push_back(wway);
         node_map[first_node].push_back(wway);
         node_map[last_node].push_back(wway);
     }
@@ -251,8 +243,10 @@ public:
 
     ~DataStorage() {
         destroy_polygons();
-        for (auto wway : waterways) {
-            delete wway;
+        for (auto node : node_map) {
+            for (auto entry : node.second) {
+                delete entry;
+            }
         }
     }
 

--- a/src/datastorage.hpp
+++ b/src/datastorage.hpp
@@ -15,8 +15,6 @@
 
 #include <gdalcpp.hpp>
 
-using namespace std;
-
 typedef osmium::index::map::Dummy<osmium::unsigned_object_id_type,
                                   osmium::Location>
         index_neg_type;
@@ -36,13 +34,13 @@ typedef osmium::handler::NodeLocationsForWays<index_pos_type,
 //};
 
 class DataStorage {
-    string output_filename;
+    std::string output_filename;
     osmium::geom::OGRFactory<> m_ogr_factory;
-    unique_ptr<gdalcpp::Dataset> m_data_source;
-    unique_ptr<gdalcpp::Layer> m_layer_polygons;
-    unique_ptr<gdalcpp::Layer> m_layer_relations;
-    unique_ptr<gdalcpp::Layer> m_layer_ways;
-    unique_ptr<gdalcpp::Layer> m_layer_nodes;
+    std::unique_ptr<gdalcpp::Dataset> m_data_source;
+    std::unique_ptr<gdalcpp::Layer> m_layer_polygons;
+    std::unique_ptr<gdalcpp::Layer> m_layer_relations;
+    std::unique_ptr<gdalcpp::Layer> m_layer_ways;
+    std::unique_ptr<gdalcpp::Layer> m_layer_nodes;
 
     /***
      * Structure to remember the waterways according to the firstnodes and
@@ -58,7 +56,7 @@ class DataStorage {
     struct WaterWay {
         osmium::object_id_type first_node;
         osmium::object_id_type last_node;
-        string name;
+        std::string name;
         char category;
 
         WaterWay(osmium::object_id_type first_node,
@@ -79,7 +77,7 @@ class DataStorage {
         }
     };
 
-    vector<WaterWay*> waterways;
+    std::vector<WaterWay*> waterways;
 
     void init_db() {
         CPLSetConfigOption("OGR_SQLITE_PRAGMA", "journal_mode=OFF,TEMP_STORE=MEMORY,temp_store=memory,LOCKING_MODE=EXCLUSIVE");
@@ -87,11 +85,11 @@ class DataStorage {
         CPLSetConfigOption("OGR_SQLITE_JOURNAL", "OFF");
         CPLSetConfigOption("OGR_SQLITE_SYNCHRONOUS", "OFF");
 
-        m_data_source = unique_ptr<gdalcpp::Dataset>{new gdalcpp::Dataset("SQlite", output_filename, gdalcpp::SRS(4326), {"SPATIALITE=YES"})};
-        m_layer_polygons = unique_ptr<gdalcpp::Layer>{new gdalcpp::Layer(*m_data_source, "polygons", wkbMultiPolygon, {"SPATIAL_INDEX=NO", "COMPRESS_GEOM=NO"})};
-        m_layer_relations = unique_ptr<gdalcpp::Layer>{new gdalcpp::Layer(*m_data_source, "relations", wkbMultiLineString, {"SPATIAL_INDEX=NO", "COMPRESS_GEOM=NO"})};
-        m_layer_ways = unique_ptr<gdalcpp::Layer>{new gdalcpp::Layer(*m_data_source, "ways", wkbLineString, {"SPATIAL_INDEX=NO", "COMPRESS_GEOM=NO"})};
-        m_layer_nodes = unique_ptr<gdalcpp::Layer>{new gdalcpp::Layer(*m_data_source, "nodes", wkbPoint, {"SPATIAL_INDEX=NO", "COMPRESS_GEOM=NO"})};
+        m_data_source = std::unique_ptr<gdalcpp::Dataset>{new gdalcpp::Dataset("SQlite", output_filename, gdalcpp::SRS(4326), {"SPATIALITE=YES"})};
+        m_layer_polygons = std::unique_ptr<gdalcpp::Layer>{new gdalcpp::Layer(*m_data_source, "polygons", wkbMultiPolygon, {"SPATIAL_INDEX=NO", "COMPRESS_GEOM=NO"})};
+        m_layer_relations = std::unique_ptr<gdalcpp::Layer>{new gdalcpp::Layer(*m_data_source, "relations", wkbMultiLineString, {"SPATIAL_INDEX=NO", "COMPRESS_GEOM=NO"})};
+        m_layer_ways = std::unique_ptr<gdalcpp::Layer>{new gdalcpp::Layer(*m_data_source, "ways", wkbLineString, {"SPATIAL_INDEX=NO", "COMPRESS_GEOM=NO"})};
+        m_layer_nodes = std::unique_ptr<gdalcpp::Layer>{new gdalcpp::Layer(*m_data_source, "nodes", wkbPoint, {"SPATIAL_INDEX=NO", "COMPRESS_GEOM=NO"})};
 
         /*---- TABLE POLYGONS ----*/
         m_layer_polygons->add_field("way_id", OFTInteger, 12);
@@ -133,8 +131,8 @@ class DataStorage {
         m_layer_nodes->add_field("way_error", OFTString, 6);
     }
 
-    const string get_timestamp(osmium::Timestamp timestamp) {
-        string time_str = timestamp.to_iso();
+    const std::string get_timestamp(osmium::Timestamp timestamp) {
+        std::string time_str = timestamp.to_iso();
         time_str.replace(10, 1, " ");
         time_str.replace(19, 1, "");
         return time_str;
@@ -150,10 +148,10 @@ class DataStorage {
             width = 0;
             return false;
         }
-        string width_str = width_chr;
+        std::string width_str = width_chr;
         bool error = false;
 
-        if (width_str.find(",") != string::npos) {
+        if (width_str.find(",") != std::string::npos) {
             width_str.replace(width_str.find(","), 1, ".");
             error = true;
             width_chr = width_str.c_str();
@@ -195,9 +193,9 @@ class DataStorage {
         return error;
     }
 
-    string width2string(float &width) {
+    std::string width2string(float &width) {
         int rounded_width = static_cast<int> (round(width * 10));
-        string width_str = to_string(rounded_width);
+        std::string width_str = std::to_string(rounded_width);
         if (width_str.length() == 1) {
             width_str.insert(width_str.begin(), '0');
         }
@@ -234,14 +232,14 @@ public:
      * polygon_tree: contains prepared polygons of all water polygons except of
      * riverbanks found in pass 4. 
      */
-    google::sparse_hash_map<osmium::object_id_type, vector<WaterWay*>> node_map;
+    google::sparse_hash_map<osmium::object_id_type, std::vector<WaterWay*>> node_map;
     google::sparse_hash_map<osmium::object_id_type, ErrorSum*> error_map;
 //    geos::index::strtree::STRtree error_tree;
     google::sparse_hash_set<geos::geom::prep::PreparedPolygon*> prepared_polygon_set;
     google::sparse_hash_set<geos::geom::MultiPolygon*> multipolygon_set;
     geos::index::strtree::STRtree polygon_tree;
 
-    explicit DataStorage(string outfile) :
+    explicit DataStorage(std::string outfile) :
             output_filename(outfile),
             m_ogr_factory() {
         init_db();
@@ -258,7 +256,7 @@ public:
         }
     }
 
-    void insert_polygon_feature(unique_ptr<OGRMultiPolygon>&& geom, const osmium::Area &area) {
+    void insert_polygon_feature(std::unique_ptr<OGRMultiPolygon>&& geom, const osmium::Area &area) {
         osmium::object_id_type way_id;
         osmium::object_id_type relation_id;
         if (area.from_way()) {
@@ -284,14 +282,14 @@ public:
                               get_timestamp(area.timestamp()).c_str());
             feature.add_to_layer();
         } catch (osmium::geometry_error& err) {
-            cerr << "Failed to create geometry feature for polygon of ";
-            if (area.from_way()) cerr << "way: ";
-            else cerr << "relation: ";
-            cerr << area.orig_id() << endl;
+            std::cerr << "Failed to create geometry feature for polygon of ";
+            if (area.from_way()) std::cerr << "way: ";
+            else std::cerr << "relation: ";
+            std::cerr << area.orig_id() << '\n';
         }
     }
 
-    void insert_relation_feature(unique_ptr<OGRGeometry>&& geom,
+    void insert_relation_feature(std::unique_ptr<OGRGeometry>&& geom,
                                  const osmium::Relation &relation,
                                  bool contains_nowaterway) {
         const std::string type = TagCheck::get_way_type(relation);
@@ -312,11 +310,11 @@ public:
                 feature.set_field("nowaterway_error", "false");
             feature.add_to_layer();
         } catch (osmium::geometry_error& err) {
-            cerr << "Failed to create relation feature:" << err.what() << "\n";
+            std::cerr << "Failed to create relation feature:" << err.what() << "\n";
         }
     }
 
-    void insert_way_feature(unique_ptr<OGRGeometry>&& geom,
+    void insert_way_feature(std::unique_ptr<OGRGeometry>&& geom,
                             const osmium::Way &way,
                             osmium::object_id_type rel_id) {
         const std::string type = TagCheck::get_way_type(way);
@@ -349,8 +347,8 @@ public:
             feature.set_field("width_error", (width_err) ? "true" : "false");
             feature.add_to_layer();
         } catch (osmium::geometry_error& err) {
-            cerr << "Failed to create geometry feature for way: "
-                 << way.id() << endl;
+            std::cerr << "Failed to create geometry feature for way: "
+                 << way.id() << '\n';
         }
 
         remember_way(first_node, last_node, std::move(name), type);
@@ -363,11 +361,11 @@ public:
         try {
             point = m_ogr_factory.create_point(location);
         } catch (osmium::geometry_error&) {
-            cerr << "Error at node: " << node_id << endl;
+            std::cerr << "Error at node: " << node_id << '\n';
             return;
         } catch (...) {
-            cerr << "Error at node: " << node_id << endl 
-                 << "Unexpected error" << endl;
+            std::cerr << "Error at node: " << node_id << '\n'
+                 << "Unexpected error" << '\n';
             return;
         }
 

--- a/src/errorsum.hpp
+++ b/src/errorsum.hpp
@@ -6,8 +6,6 @@
 #ifndef ERRORSUM_HPP_
 #define ERRORSUM_HPP_
 
-using namespace std;
-
 #define CHECK_BIT(var,pos) ((var) & (1<<(pos)))
 
 class ErrorSum {

--- a/src/falsepositives.hpp
+++ b/src/falsepositives.hpp
@@ -40,12 +40,12 @@ class IndicateFalsePositives: public osmium::handler::Handler {
     }
 
     void errormsg(const osmium::Area &area) {
-        cerr << "IndicateFalsePositives: Error at ";
+        std::cerr << "IndicateFalsePositives: Error at ";
         if (area.from_way())
-            cerr << "way: ";
+            std::cerr << "way: ";
         else
-            cerr << "relation: ";
-        cerr << area.orig_id() << endl;
+            std::cerr << "relation: ";
+        std::cerr << area.orig_id() << '\n';
     }
 
     /***
@@ -122,11 +122,11 @@ public:
                 location = location_handler.get_node_location(node_id);
                 point = geos_factory.create_point(location).release();
             } catch (...) {
-                cerr << "Error at node: " << node_id
-                     << " - not able to create point of location." << endl;
+                std::cerr << "Error at node: " << node_id
+                     << " - not able to create point of location.\n";
                 continue;
             }
-            vector<void *> results;
+            std::vector<void *> results;
             ds.polygon_tree.query(point->getEnvelopeInternal(), results);
             if (results.size()) {
                 for (auto result : results) {

--- a/src/tagcheck.hpp
+++ b/src/tagcheck.hpp
@@ -14,8 +14,6 @@
 #include <osmium/tags/tags_filter.hpp>
 
 
-using namespace std;
-
 class TagCheck {
 
     static const std::string get_waterway_type(const char *raw_type) {

--- a/src/tagcheck.hpp
+++ b/src/tagcheck.hpp
@@ -8,6 +8,7 @@
 #ifndef TAGCHECK_HPP_
 #define TAGCHECK_HPP_
 
+#include <string>
 #include <osmium/osm/tag.hpp>
 #include <osmium/tags/filter.hpp>
 #include <osmium/tags/tags_filter.hpp>
@@ -17,17 +18,17 @@ using namespace std;
 
 class TagCheck {
 
-    static const char *get_waterway_type(const char *raw_type) {
+    static const std::string get_waterway_type(const char *raw_type) {
         if (!raw_type) {
-            return nullptr;
+            return "";
         }
         if ((strcmp(raw_type, "river")) && (strcmp(raw_type, "stream")) 
                 && (strcmp(raw_type, "drain")) && (strcmp(raw_type, "brook"))
                 && (strcmp(raw_type, "canal")) && (strcmp(raw_type,"ditch"))
                 && (strcmp(raw_type, "riverbank"))) {
-            return strdup("other\0");
+            return "other";
         } else {
-            return strdup(raw_type);
+            return raw_type;
         }
     }
 
@@ -164,66 +165,51 @@ public:
         }
     }
 
-    static const char *get_polygon_type(const osmium::Area &area) {
-        const char *type;
+    static const std::string get_polygon_type(const osmium::Area &area) {
         const char *natural = area.get_value_by_key("natural");
         if ((natural) && (!strcmp(natural, "coastline"))) {
-            type = "coastline";
-        } else {
-            type = get_waterway_type(area.get_value_by_key("waterway"));
-            //if (!type) {
-            //    type = area.get_value_by_key("water");
-            //}
-            if (!type) {
-                type = area.get_value_by_key("landuse");
-            }
-            if (!type) type = "";
+            return "coastline";
         }
-        return type;
+        if (get_waterway_type(area.get_value_by_key("waterway")).empty()) {
+            return area.get_value_by_key("landuse", "");
+        }
+        return "";
     }
 
-    static const char *get_way_type(const osmium::OSMObject &osm_object) {
-        const char *type;
+    static const std::string get_way_type(const osmium::OSMObject &osm_object) {
         const char *waterway = osm_object.get_value_by_key("waterway");
-        type = get_waterway_type(waterway);
-        if (!type) {
+        std::string type = get_waterway_type(waterway);
+        if (type.empty()) {
             const char *natural = osm_object.get_value_by_key("natural");
             if ((natural) && (!strcmp(natural, "coastline"))) {
-                type = "coastline";
+                return "coastline";
+            } else {
+                return "";
             }
         }
-        if (!type) type = "";
         return type;
-    }
-
-    static const char *get_name(const osmium::OSMObject &osm_object) {
-        const char *name = osm_object.get_value_by_key("name");
-        if (!name) name = "";
-        return name;
     }
 
     static const char *get_width(const osmium::OSMObject &osm_object) {
-        const char *width;
-        if (osm_object.get_value_by_key("width")) {
-            width = osm_object.get_value_by_key("width");
-        } else if (osm_object.get_value_by_key("est_width")) {
-            width = osm_object.get_value_by_key("est_width");
-        } else {
-            width = "";
+        const char *width = osm_object.get_value_by_key("width");
+        if (width) {
+            return width;
+        }
+        width = osm_object.get_value_by_key("est_width");
+        if (width) {
+            return width;
         }
         return width;
     }
 
-    static const char *get_construction(const osmium::OSMObject &osm_object) {
-        const char *construction;
+    static const std::string get_construction(const osmium::OSMObject &osm_object) {
         if (osm_object.get_value_by_key("bridge")) {
-            construction = "bridge";
-        } else if (osm_object.get_value_by_key("tunnel")) {
-            construction = "tunnel";
-        } else {
-            construction = "";
+            return "bridge";
         }
-        return construction;
+        if (osm_object.get_value_by_key("tunnel")) {
+            return "tunnel";
+        }
+        return "";
     }
 };
 

--- a/src/waterinspector.cpp
+++ b/src/waterinspector.cpp
@@ -39,8 +39,6 @@
 #include "falsepositives.hpp"
 #include "areahandler.hpp"
 
-using namespace std;
-
 typedef osmium::index::map::Dummy<osmium::unsigned_object_id_type,
         osmium::Location> index_neg_type;
 typedef osmium::index::map::SparseMemArray<osmium::unsigned_object_id_type,
@@ -51,10 +49,10 @@ typedef osmium::handler::NodeLocationsForWays<index_pos_type, index_neg_type>
 typedef geos::geom::LineString linestring_type;
 
 void print_help() {
-    cout << "osmi [OPTIONS] INFILE OUTFILE\n\n"
+    std::cout << "osmi [OPTIONS] INFILE OUTFILE\n\n"
             << "  -h, --help           This help message\n"
             //<< "  -d, --debug          Enable debug output !NOT IN USE\n"
-            << endl;
+            << std::endl;
 }
 
 int main(int argc, char* argv[]) {
@@ -81,17 +79,17 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    string input_filename;
-    string output_filename;
+    std::string input_filename;
+    std::string output_filename;
     int remaining_args = argc - optind;
     if ((remaining_args < 2) || (remaining_args > 4)) {
-        cerr << "Usage: " << argv[0] << " [OPTIONS] INFILE OUTFILE" << endl;
-        cerr << remaining_args;
+        std::cerr << "Usage: " << argv[0] << " [OPTIONS] INFILE OUTFILE" << '\n';
+        std::cerr << remaining_args;
         exit(1);
     } else if (remaining_args == 2) {
         input_filename = argv[optind];
         output_filename = argv[optind + 1];
-        cout << "in: " << input_filename << " out: " << output_filename << endl;
+        std::cout << "in: " << input_filename << " out: " << output_filename << '\n';
     } else {
         input_filename = "-";
     }
@@ -113,16 +111,16 @@ int main(int argc, char* argv[]) {
      * Pass 1: waterway_collector and waterpolygon_collector remember the ways
      * according to a relation.
      */
-    cerr << "Pass 1..." << endl;
+    std::cerr << "Pass 1...\n";
     osmium::relations::read_relations(osmium::io::File(input_filename), waterway_collector, waterpolygon_collector);
-    cerr << "Pass 1 done" << endl;
+    std::cerr << "Pass 1 done\n";;
 
     /***
      * Pass 2: Collect all waterways in and not in any relation.
      * Insert features to ways and relations table.
      * analyse_nodes is detecting all possibly errors and mouths.
      */
-    cerr << "Pass 2..." << endl;
+    std::cerr << "Pass 2...\n";
     AreaHandler area_handler(ds);
     osmium::io::Reader reader2(input_filename);
     osmium::apply(reader2, location_handler, waterway_collector.handler(),
@@ -134,25 +132,25 @@ int main(int argc, char* argv[]) {
     waterway_collector.ways_in_incomplete_relation();
     waterway_collector.analyse_nodes();
     reader2.close();
-    cerr << "Pass 2 done" << endl;
+    std::cerr << "Pass 2 done\n";
 
     /***
      * Pass 3: Indicate false positives by comparing the error nodes with the
      * way nodes between the firstnode and the lastnode.
      */
-    cerr << "Pass 3..." << endl;
+    std::cerr << "Pass 3...\n";
     osmium::io::Reader reader3(input_filename, osmium::osm_entity_bits::way);
     IndicateFalsePositives indicate_false_positives(ds, location_handler);
     osmium::apply(reader3, indicate_false_positives);
     reader3.close();
     area_handler.complete_polygon_tree();
     indicate_false_positives.check_area();
-    cerr << "Pass 3 done" << endl;
+    std::cerr << "Pass 3 done\n";
 
     /***
      * Insert the error nodes into the nodes table.
      */
     ds.insert_error_nodes(location_handler);
 
-    cout << "ready" << endl;
+    std::cout << "ready\n";
 }

--- a/src/waterinspector.cpp
+++ b/src/waterinspector.cpp
@@ -28,8 +28,6 @@
 #include <geos/geom/GeometryFactory.h>
 #include <geos/index/strtree/STRtree.h>
 #include <geos/io/WKBWriter.h>
-#include <google/sparse_hash_set>
-#include <google/sparse_hash_map>
 
 #include "errorsum.hpp"
 #include "waterway.hpp"

--- a/src/waterway.hpp
+++ b/src/waterway.hpp
@@ -378,7 +378,8 @@ public:
 
             count_first_node = 0; count_last_node = 0;
             names.clear(); category_in.clear(); category_out.clear();
-            for (auto wway : node.second) {
+            for (auto wway_idx : node.second) {
+                DataStorage::WaterWay* wway = &(ds.get_waterway(wway_idx));
                 if (wway->first_node == node_id) {
                     count_first_node++;
                     names.push_back(wway->name.c_str());


### PR DESCRIPTION
* Use `std::vector`, not `google::sparse_hash_set` to store the pointers to the geometries which have been inserted into the GEOS geometry index.
* Don't create instances of `WaterWay` on the heap with `new`, don't store vectors of pointers to them in a map but store the instances of `WaterWay` in a vector and store vectors of offsets (`std::size_t`) in the map. This avoids that we have to free the memory ourselves.
* Fix some potential memory leaks. Use `std::string` more often.
* Get rid of `using namespace std`.